### PR TITLE
Fix extract.js for Node.js 18.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # vue-gettext-tools
 
+This is a modified version of Gettext tools from eldarc/vue-gettext-tools.
+
 # NOTE: Plugin ready for first version; Documentation is in progress.
 
 Extract and compile gettext strings from Vue source files.

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -45,7 +45,7 @@ var _colors = require('colors');
 
 var _colors2 = _interopRequireDefault(_colors);
 
-var _vue2 = require('vue/dist/vue');
+var _vue2 = require('vue/dist/vue.js');
 
 var _vue3 = _interopRequireDefault(_vue2);
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "vue-gettext-tools",
+  "name": "@kngai/vue-gettext-tools",
   "version": "0.0.7",
-  "description": "Gettext tools for Vue.js to help extract strings and compile gettext files.",
-  "repository": "git@github.com:eldarc/vue-gettext-tools.git",
-  "author": "Eldar Cejvanovic <eldar.cejvanovic@gmail.com>",
+  "description": "Modified version of Gettext tools from eldarc/vue-gettext-tools for Vue.js to help extract strings and compile gettext files.",
+  "repository": "git@github.com:kngai/vue-gettext-tools.git",
+  "author": "Kevin Ngai <kevin.ngai@ec.gc.ca>",
   "license": "MIT",
   "scripts": {
     "build": "gulp",


### PR DESCRIPTION
This PR addresses a simple fix after I upgraded to Node.js 18.16 (current LTS version) while using `vue 2.7.14` and `@vue/cli 5.0.8`.

When I tried to use `Extractor` or `Compiler` in my `gettext-extract.js` Node script:
```js
const { Extractor } = require('vue-gettext-tools')

const extractorConfig = {verbose: true}

Extractor(extractorConfig, ['src/**/*.{vue,js}'], 'locales/po/dictionary.pot')
```

I ended up with a `MODULE_NOT_FOUND` error like so:

```sh
> node build/gettext-extract.js

node:internal/modules/cjs/loader:571
      throw e;
      ^

Error: Cannot find module 'C:\Users\path\to\my\project\node_modules\vue\dist\vue'
    at createEsmNotFoundErr (node:internal/modules/cjs/loader:1096:15)
    at finalizeEsmResolution (node:internal/modules/cjs/loader:1089:15)
    at resolveExports (node:internal/modules/cjs/loader:565:14)
    at Module._findPath (node:internal/modules/cjs/loader:634:31)
    at Module._resolveFilename (node:internal/modules/cjs/loader:1061:27)
    at Module._load (node:internal/modules/cjs/loader:920:27)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at require (node:internal/modules/cjs/helpers:110:18)
    at Object.<anonymous> (C:\Users\path\to\my\project\node_modules\vue-gettext-tools\lib\extract.js:48:13)
    at Module._compile (node:internal/modules/cjs/loader:1254:14) {
  code: 'MODULE_NOT_FOUND',
  path: 'C:\\Users\\path\to\my\project\\node_modules\\vue\\package.json'
}

Node.js v18.16.0
```

Appending a `.js` to become `var _vue2 = require('vue/dist/vue.js');` solved the issue.